### PR TITLE
Fix polygon winding order

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -57,8 +57,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="vectorTile">The vector tile.</param>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="extent">The extent.</param>
-        /// <param name="idAttributeName">The name of an attribute property to use as the ID for the Feature.</param>
-        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096, string idAttributeName = "id")
+        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096)
         {
             var tile = new Tiles.Tile(vectorTile.TileId);
             var tgt = new TileGeometryTransform(tile, extent);
@@ -101,12 +100,6 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
 
                     // Translate attributes for feature
                     AddAttributes(feature.Tags, keys, values, localLayerFeature.Attributes);
-
-                    var id = localLayerFeature.Attributes.GetOptionalValue(idAttributeName);
-                    if (id != null && ulong.TryParse(id.ToString(), out idVal))
-                    {
-                        feature.Id = idVal;
-                    }
 
                     // Add feature to layer
                     layer.Features.Add(feature);

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -221,11 +221,12 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 if (polygon.Area == 0d)
                     continue;
 
-                foreach (uint encoded in Encode(polygon.Shell.CoordinateSequence, tgt, ref currentX, ref currentY, true, true))
+                //Shell rings should be CW, holes CCW as per spec: https://docs.mapbox.com/vector-tiles/specification/
+                foreach (uint encoded in Encode(polygon.Shell.CoordinateSequence, tgt, ref currentX, ref currentY, true, false))
                     yield return encoded;
                 foreach (var hole in polygon.InteriorRings)
                 {
-                    foreach (uint encoded in Encode(hole.CoordinateSequence, tgt, ref currentX, ref currentY, true, false))
+                    foreach (uint encoded in Encode(hole.CoordinateSequence, tgt, ref currentX, ref currentY, true, true))
                         yield return encoded;
                 }
             }

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -57,7 +57,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="vectorTile">The vector tile.</param>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="extent">The extent.</param>
-        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096)
+        /// <param name="idAttributeName">The name of an attribute property to use as the ID for the Feature.</param>
+        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096, string idAttributeName = "id")
         {
             var tile = new Tiles.Tile(vectorTile.TileId);
             var tgt = new TileGeometryTransform(tile, extent);
@@ -100,6 +101,12 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
 
                     // Translate attributes for feature
                     AddAttributes(feature.Tags, keys, values, localLayerFeature.Attributes);
+
+                    var id = localLayerFeature.Attributes.GetOptionalValue(idAttributeName);
+                    if (id != null && ulong.TryParse(id.ToString(), out idVal))
+                    {
+                        feature.Id = idVal;
+                    }
 
                     // Add feature to layer
                     layer.Features.Add(feature);


### PR DESCRIPTION
I noticed an odd rendering issue with the vector tiles generated using the MapboxTileWriter. Random polygons where not rendering in Mapbox and when I extruded any polygons, they were missing faces. After a full day of debugging my app I track the issue down to a small bug in this project. The issue is with the winding order of the polygons. The [Mapbox Vector Tile Specification](https://docs.mapbox.com/vector-tiles/specification/) says that the shell ring should be CW and holes be CWW oriented. This is the opposite of the OGC standard which is likely where the confusion came from.