### PR TITLE
Add support for Feature IDs

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -57,7 +57,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="vectorTile">The vector tile.</param>
         /// <param name="stream">The stream to write to.</param>
         /// <param name="extent">The extent.</param>
-        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096)
+        /// <param name="idAttributeName">The name of an attribute property to use as the ID for the Feature.</param>
+        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096, string idAttributeName = "id")
         {
             var tile = new Tiles.Tile(vectorTile.TileId);
             var tgt = new TileGeometryTransform(tile, extent);
@@ -100,6 +101,13 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
 
                     // Translate attributes for feature
                     AddAttributes(feature.Tags, keys, values, localLayerFeature.Attributes);
+
+                    //Try and retrieve an ID from the attributes.
+                    var id = localLayerFeature.Attributes.GetOptionalValue(idAttributeName);
+                    if (id != null && ulong.TryParse(id.ToString(), out idVal))
+                    {
+                        feature.Id = idVal;
+                    }
 
                     // Add feature to layer
                     layer.Features.Add(feature);


### PR DESCRIPTION
NetTopologySuite features don't have an ID property. As such, this library isn't currently assigning any ID value to any features when writing tiles. This creates some limitations when using the tiles elsewhere (i.e. more difficult to use feature states).

There are two common approaches used by many as a workaround;

1. Add the ID as a value in the attribute table. This is simple and easy to use.
2. Create and extention on the Geometry class that adds set/get support for an ID value. This is a bit more involved and has a greater potential of conflict as other libraries/developers may have implemented a similar extension as a solution.

Given the simplicity of option 1, this PR adds a support for specifying which attribute should be used as an ID for the feature in the tile. This is fully backwards compatible. By default it will look for an attribute called "id" (you can pass in a different value to use). If no attribute with the specified key is found, it simply won't assign any ID. If it does find a value, it then tries to parse it as a ulong, and if successful, passes the value in as the ID on the feature.
Here is an example of using an "id" attribute in a NetTopology Feature:

```
var layer = new NetTopologySuite.IO.VectorTiles.Layer()
{
    Name = "test"
};

layer.Features.Add(new Feature(new Point(0, 0), new AttributesTable(new Dictionary<string, object>() {
    { "id", 12345 }
})));
```

The writer will automatically detect the ID and use it, no changes needed.

Here is an example of passing in a custom ID value into a NetTopology Feature:

```
var layer = new NetTopologySuite.IO.VectorTiles.Layer()
{
    Name = "test"
};

layer.Features.Add(new Feature(new Point(0, 0), new AttributesTable(new Dictionary<string, object>() {
    { "myCustomID", 12345 }
})));
```

Here is an example of telling the writer to use the custom ID:

```
NetTopologySuite.IO.VectorTiles.Mapbox.MapboxTileWriter.Write(tile, fs, null, "myCustomID");
```