### PR TITLE
Ensure vector tile layers include extent

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/Tile.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/Tile.cs
@@ -198,7 +198,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             }
 
             uint _extent = 4096;
-            [ProtoBuf.ProtoMember(5, IsRequired = false, Name = @"extent", DataFormat = ProtoBuf.DataFormat.TwosComplement)]
+            [ProtoBuf.ProtoMember(5, IsRequired = true, Name = @"extent", DataFormat = ProtoBuf.DataFormat.TwosComplement)]
             [System.ComponentModel.DefaultValue((uint)4096)]
             public uint Extent
             {


### PR DESCRIPTION
I ran into several tools that complained that the vector tiles I created with this tool were missing the Extent value on the individual layers. Looking in the code I noticed that this was marked as not required and as a result the default value wasn't being included in the tiles. Other tools that didn't validate the tiles ran into issues as they defaulted the extent to 0. According to Mapbox vector tile spec, the Extent value must be specified in each layer.