### PR TITLE
MapboxTileWriter coordinates count check

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -269,7 +269,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             bool ring = false, bool ccw = false)
         {
             // how many parameters for LineTo command
-            int count = sequence.Count;
+            // skipping the last point for rings since ClosePath is used instead
+            int count = ring ? sequence.Count - 1 : sequence.Count;
 
             // If the sequence is empty there is nothing we can do with it.
             if (count == 0)

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -212,11 +212,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 if (point.IsEmpty) continue;
 
                 (int x, int y) = tgt.Transform(point.CoordinateSequence, CoordinateIndex, ref currentX, ref currentY);
-                if (i == 0 || x > 0 || y > 0)
-                {
-                    parameters.Add(GenerateParameterInteger(x));
-                    parameters.Add(GenerateParameterInteger(y));
-                }
+                parameters.Add(GenerateParameterInteger(x));
+                parameters.Add(GenerateParameterInteger(y));
             }
 
             // Return result

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -211,9 +211,21 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 // if the point is empty, there is nothing we can do with it
                 if (point.IsEmpty) continue;
 
+                int previousX = currentX, previousY = currentY;
                 (int x, int y) = tgt.Transform(point.CoordinateSequence, CoordinateIndex, ref currentX, ref currentY);
-                parameters.Add(GenerateParameterInteger(x));
-                parameters.Add(GenerateParameterInteger(y));
+
+                if (i == 0 || tgt.IsPointInExtent(currentX, currentY))
+                {
+                    parameters.Add(GenerateParameterInteger(x));
+                    parameters.Add(GenerateParameterInteger(y));
+                }
+                else
+                {
+                    // discard point if it lies outside tile extent and rollback to previous point
+                    // only for the case of multipoint
+                    currentX = previousX;
+                    currentY = previousY;
+                }
             }
 
             // Return result

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -83,5 +83,16 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             var coordinates = WebMercatorHandler.MetersToLatLon(meters);
             return coordinates;
         }
+
+        /// <summary>
+        /// Check if the point with tile coordinates (<paramref name="x"/>, <paramref name="y"/> lies inside tile extent
+        /// </summary>
+        /// <param name="x">Horizontal component of the point in the tile coordinate system</param>
+        /// <param name="y">Vertical component of the point in the tile coordinate system</param>
+        /// <returns>true if point lies inside tile extent</returns>
+        public bool IsPointInExtent(int x, int y)
+        {
+            return x >= 0 && y >= 0 && x < _extent && y < _extent;
+        }
     }
 }

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripBase.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripBase.cs
@@ -103,8 +103,14 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
             double error = 2 * System.Math.Sqrt(pixelDiff * pixelDiff * 2) / Extent;
             if (expected is IPuntal)
             {
-                double test = expected.Distance(parsed);
-                Assert.True(test < error);
+                // In MultiPoint case check all points that forms it
+                for (int i = 0; i < expected.NumGeometries; i++)
+                {
+                    var expectedPoint = (Point)expected.GetGeometryN(i);
+                    var parsedPoint = (Point)parsed.GetGeometryN(i);
+                    double test = expectedPoint.Distance(parsedPoint);
+                    Assert.True(test < error);
+                }
             }
             else
                 Assert.True(new HausdorffSimilarityMeasure().Measure(expected, parsed) > 1 - error);

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripBase.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripBase.cs
@@ -96,6 +96,9 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
             // Points checked
             Assert.Equal(expected.OgcGeometryType, parsed.OgcGeometryType);
 
+            // Coordinates count checked
+            Assert.Equal(expected.Coordinates.Length, parsed.Coordinates.Length);
+
             double pixelDiff = (85.5 * 2);
             double error = 2 * System.Math.Sqrt(pixelDiff * pixelDiff * 2) / Extent;
             if (expected is IPuntal)

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripTests.cs
@@ -142,6 +142,20 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
         }
 
         [Fact]
+        public void test_encode_multipoint_point_outside_extent()
+        {
+            AssertRoundTrip("MULTIPOINT((10 10), (20 20), (185 40), (30 10))",
+                "{\"type\": \"MultiPoint\",\"coordinates\": [[10, 10], [20, 20], [30, 10]]}");
+        }
+
+        [Fact]
+        public void test_encode_multipoint_first_point_outside_extent()
+        {
+            AssertRoundTrip("MULTIPOINT((185 40), (10 10), (20 20), (30 10))",
+                "{\"type\": \"MultiPoint\",\"coordinates\": [[185, 40], [10, 10], [20, 20], [30, 10]]}");
+        }
+
+        [Fact]
         public void test_encode_multilinestring()
         {
             AssertRoundTrip("MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))",


### PR DESCRIPTION
Found two problems during testing.
* For polygons, the encoding method inserts an extra point to close the rings. This should be done only via the ClosePath command, otherwise the last point is duplicated after reading the tile.
Added coordinates count check in RoundTrip geometry check method.

* After adding a check for the number of coordinates, the multipoint test stopped working because some points were discarded due to negative coordinates at this line:
https://github.com/NetTopologySuite/NetTopologySuite.IO.VectorTiles/blob/83c856de17e447634b94ac9bb321b9040ce0bce3/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs#L215

This check looks strange. I didn't quite understand what was being checked here. 
Why does one coordinate of a point have to be positive? 
A point can still go beyond the extent's boundaries if one coordinate is negative or larger than the extent size (4096).

Removed this check for now, but I'm not sure it's right)