### PR TITLE
Mapbox Vector Tiles: Integer local tile coordinates

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
-using NetTopologySuite.IO.VectorTiles.Tiles.WebMercator;
 
 namespace NetTopologySuite.IO.VectorTiles.Mapbox
 {

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -269,7 +269,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             bool ring = false, bool ccw = false)
         {
             // how many parameters for LineTo command
-            int count = sequence.Count;
+            // skipping the last point for rings since ClosePath is used instead
+            int count = ring ? sequence.Count - 1 : sequence.Count;
 
             // If the sequence is empty there is nothing we can do with it.
             if (count == 0)

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -212,11 +212,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 if (point.IsEmpty) continue;
 
                 (int x, int y) = tgt.Transform(point.CoordinateSequence, CoordinateIndex, ref currentX, ref currentY);
-                if (i == 0 || x > 0 || y > 0)
-                {
-                    parameters.Add(GenerateParameterInteger(x));
-                    parameters.Add(GenerateParameterInteger(y));
-                }
+                parameters.Add(GenerateParameterInteger(x));
+                parameters.Add(GenerateParameterInteger(y));
             }
 
             // Return result

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -211,9 +211,21 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 // if the point is empty, there is nothing we can do with it
                 if (point.IsEmpty) continue;
 
+                int previousX = currentX, previousY = currentY;
                 (int x, int y) = tgt.Transform(point.CoordinateSequence, CoordinateIndex, ref currentX, ref currentY);
-                parameters.Add(GenerateParameterInteger(x));
-                parameters.Add(GenerateParameterInteger(y));
+
+                if (i == 0 || tgt.IsPointInExtent(currentX, currentY))
+                {
+                    parameters.Add(GenerateParameterInteger(x));
+                    parameters.Add(GenerateParameterInteger(y));
+                }
+                else
+                {
+                    // discard point if it lies outside tile extent and rollback to previous point
+                    // only for the case of multipoint
+                    currentX = previousX;
+                    currentY = previousY;
+                }
             }
 
             // Return result

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -251,7 +251,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             var geometry = (Geometry)polygonal;
 
             //Test the whole polygon geometry is larger than a single pixel.
-            if (IsGreaterThanOnePixelOfTile(geometry, zoom))
+            if (tgt.IsGreaterThanOnePixelOfTile(geometry))
             {
                 int currentX = 0, currentY = 0;
                 for (int i = 0; i < geometry.NumGeometries; i++)
@@ -259,7 +259,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                     var polygon = (Polygon)geometry.GetGeometryN(i);
 
                     //Test that individual polygons are larger than a single pixel.
-                    if (!IsGreaterThanOnePixelOfTile(polygon, zoom))
+                    if (!tgt.IsGreaterThanOnePixelOfTile(polygon))
                         continue;
 
                     foreach (uint encoded in Encode(polygon.Shell.CoordinateSequence, tgt, ref currentX, ref currentY, true, false))
@@ -377,26 +377,6 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         private static uint GenerateParameterInteger(int value)
         { // ParameterInteger = (value << 1) ^ (value >> 31)
             return (uint)((value << 1) ^ (value >> 31));
-        }
-
-        /// <summary>
-        /// Checks to see if a geometries envelope is greater than 1 square pixel in size for a specified zoom leve.
-        /// </summary>
-        /// <param name="polygon">Polygon to test.</param>
-        /// <param name="zoom">Zoom level </param>
-        /// <returns></returns>
-        private static bool IsGreaterThanOnePixelOfTile(Geometry polygon, int zoom)
-        {
-            if (polygon.IsEmpty) return false;
-
-            (double x1, double y1) = WebMercatorHandler.MetersToPixels(WebMercatorHandler.LatLonToMeters(polygon.EnvelopeInternal.MinY, polygon.EnvelopeInternal.MinX), zoom, 512);
-            (double x2, double y2) = WebMercatorHandler.MetersToPixels(WebMercatorHandler.LatLonToMeters(polygon.EnvelopeInternal.MaxY, polygon.EnvelopeInternal.MaxX), zoom, 512);
-
-            double dx = Math.Abs(x2 - x1);
-            double dy = Math.Abs(y2 - y1);
-
-            //Both must be greater than 0, and atleast one of them needs to be larger than 1. 
-            return dx > 0 && dy > 0 && (dx > 1 || dy > 1);
         }
     }
 }

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -83,5 +83,16 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             var coordinates = WebMercatorHandler.MetersToLatLon(meters);
             return coordinates;
         }
+
+        /// <summary>
+        /// Check if the point with tile coordinates (<paramref name="x"/>, <paramref name="y"/> lies inside tile extent
+        /// </summary>
+        /// <param name="x">Horizontal component of the point in the tile coordinate system</param>
+        /// <param name="y">Vertical component of the point in the tile coordinate system</param>
+        /// <returns>true if point lies inside tile extent</returns>
+        public bool IsPointInExtent(int x, int y)
+        {
+            return x >= 0 && y >= 0 && x < _extent && y < _extent;
+        }
     }
 }

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -99,5 +99,24 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         {
             return x >= 0 && y >= 0 && x < _extent && y < _extent;
         }
+
+        /// <summary>
+        /// Checks to see if a geometries envelope is greater than 1 square pixel in size for a specified zoom level.
+        /// </summary>
+        /// <param name="polygon">Polygon to test.</param>
+        /// <returns>true if the <paramref name="polygon"/> is greater than 1 pixel in the tile pixel coordinates</returns>
+        public bool IsGreaterThanOnePixelOfTile(Geometry polygon)
+        {
+            if (polygon.IsEmpty) return false;
+
+            (double x1, double y1) = WebMercatorHandler.MetersToPixels(WebMercatorHandler.LatLonToMeters(polygon.EnvelopeInternal.MinY, polygon.EnvelopeInternal.MinX), ZoomResolution);
+            (double x2, double y2) = WebMercatorHandler.MetersToPixels(WebMercatorHandler.LatLonToMeters(polygon.EnvelopeInternal.MaxY, polygon.EnvelopeInternal.MaxX), ZoomResolution);
+
+            double dx = Math.Abs(x2 - x1);
+            double dy = Math.Abs(y2 - y1);
+
+            // Both must be greater than 0, and at least one of them needs to be larger than 1. 
+            return dx > 0 && dy > 0 && (dx > 1 || dy > 1);
+        }
     }
 }

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -11,10 +11,10 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
     /// </summary>
     internal struct TileGeometryTransform
     {
-        private Tiles.Tile _tile;
-        private uint _extent;
-        private long _top;
-        private long _left;
+        private readonly Tiles.Tile _tile;
+        private readonly uint _extent;
+        private readonly long _top;
+        private readonly long _left;
 
         /// <summary>
         /// Initializes this transformation utility
@@ -26,19 +26,17 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             _tile = tile;
             _extent = extent;
 
-            //Precalculate the resolution of the tile for the specified zoom level.
+            // Precalculate the resolution of the tile for the specified zoom level.
             this.ZoomResolution = WebMercatorHandler.Resolution(tile.Zoom, (int)extent);
 
             var meters = WebMercatorHandler.LatLonToMeters(_tile.Top, _tile.Left);
-            var pixels = WebMercatorHandler.MetersToPixels(meters, this.ZoomResolution);
-            _top = (long)pixels.y;
-            _left = (long)pixels.x;
+            (_left, _top) = WebMercatorHandler.MetersToPixels(meters, this.ZoomResolution);
         }
 
         /// <summary>
         /// The zoom level pixel resolution based on the extent.
         /// </summary>
-        public double ZoomResolution { get; private set; }
+        public double ZoomResolution { get; }
 
         /// <summary>
         /// Transforms the coordinate at <paramref name="index"/> of <paramref name="sequence"/> to the tile coordinate system.
@@ -76,8 +74,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
 
         public (double longitude, double latitude) TransformInverse(int x, int y)
         {
-            double globalX = _left + x;
-            double globalY = _top - y;
+            long globalX = _left + x;
+            long globalY = _top - y;
 
             var meters = WebMercatorHandler.PixelsToMeters((globalX, globalY), this.ZoomResolution);
             var coordinates = WebMercatorHandler.MetersToLatLon(meters);

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -27,10 +27,10 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             _extent = extent;
 
             // Precalculate the resolution of the tile for the specified zoom level.
-            this.ZoomResolution = WebMercatorHandler.Resolution(tile.Zoom, (int)extent);
+            ZoomResolution = WebMercatorHandler.Resolution(tile.Zoom, (int)extent);
 
             var meters = WebMercatorHandler.LatLonToMeters(_tile.Top, _tile.Left);
-            (_left, _top) = WebMercatorHandler.MetersToPixels(meters, this.ZoomResolution);
+            (_left, _top) = WebMercatorHandler.MetersToPixels(meters, ZoomResolution);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             double lat = sequence.GetOrdinate(index, Ordinate.Y);
             
             var meters = WebMercatorHandler.LatLonToMeters(lat, lon);
-            var pixels = WebMercatorHandler.MetersToPixels(meters, this.ZoomResolution);
+            var pixels = WebMercatorHandler.MetersToPixels(meters, ZoomResolution);
             
             int localX = (int) (pixels.x - _left);
             int localY = (int) (_top - pixels.y);
@@ -72,12 +72,19 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return (dx, dy);
         }
 
+        /// <summary>
+        /// Transforms the point in the local tile pixel coordinates into WGS84 coordinates.
+        /// The return value is longitude and latitude of the tile pixel point (<paramref name="x"/>, <paramref name="y"/>).
+        /// </summary>
+        /// <param name="x">The horizontal component of the point in the tile coordinate system</param>
+        /// <param name="y">The vertical component of the point in the tile coordinate system</param>
+        /// <returns>WGS84 coordinates of the point in tile "pixel" coordinates (<paramref name="x"/>, <paramref name="y"/>).</returns>
         public (double longitude, double latitude) TransformInverse(int x, int y)
         {
             long globalX = _left + x;
             long globalY = _top - y;
 
-            var meters = WebMercatorHandler.PixelsToMeters((globalX, globalY), this.ZoomResolution);
+            var meters = WebMercatorHandler.PixelsToMeters((globalX, globalY), ZoomResolution);
             var coordinates = WebMercatorHandler.MetersToLatLon(meters);
             return coordinates;
         }

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -30,7 +30,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             ZoomResolution = WebMercatorHandler.Resolution(tile.Zoom, (int)extent);
 
             var meters = WebMercatorHandler.LatLonToMeters(_tile.Top, _tile.Left);
-            (_left, _top) = WebMercatorHandler.MetersToPixels(meters, ZoomResolution);
+            (_left, _top) = WebMercatorHandler.FromMetersToPixels(meters, ZoomResolution);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             double lat = sequence.GetOrdinate(index, Ordinate.Y);
             
             var meters = WebMercatorHandler.LatLonToMeters(lat, lon);
-            var pixels = WebMercatorHandler.MetersToPixels(meters, ZoomResolution);
+            var pixels = WebMercatorHandler.FromMetersToPixels(meters, ZoomResolution);
             
             int localX = (int) (pixels.x - _left);
             int localY = (int) (_top - pixels.y);
@@ -84,7 +84,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             long globalX = _left + x;
             long globalY = _top - y;
 
-            var meters = WebMercatorHandler.PixelsToMeters((globalX, globalY), ZoomResolution);
+            var meters = WebMercatorHandler.FromPixelsToMeters((globalX, globalY), ZoomResolution);
             var coordinates = WebMercatorHandler.MetersToLatLon(meters);
             return coordinates;
         }
@@ -109,8 +109,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         {
             if (polygon.IsEmpty) return false;
 
-            (double x1, double y1) = WebMercatorHandler.MetersToPixels(WebMercatorHandler.LatLonToMeters(polygon.EnvelopeInternal.MinY, polygon.EnvelopeInternal.MinX), ZoomResolution);
-            (double x2, double y2) = WebMercatorHandler.MetersToPixels(WebMercatorHandler.LatLonToMeters(polygon.EnvelopeInternal.MaxY, polygon.EnvelopeInternal.MaxX), ZoomResolution);
+            (double x1, double y1) = WebMercatorHandler.FromMetersToPixels(WebMercatorHandler.LatLonToMeters(polygon.EnvelopeInternal.MinY, polygon.EnvelopeInternal.MinX), ZoomResolution);
+            (double x2, double y2) = WebMercatorHandler.FromMetersToPixels(WebMercatorHandler.LatLonToMeters(polygon.EnvelopeInternal.MaxY, polygon.EnvelopeInternal.MaxX), ZoomResolution);
 
             double dx = Math.Abs(x2 - x1);
             double dy = Math.Abs(y2 - y1);

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/WebMercator/WebMercatorHandler.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/WebMercator/WebMercatorHandler.cs
@@ -2,14 +2,22 @@ using System;
 
 namespace NetTopologySuite.IO.VectorTiles.Tiles.WebMercator
 {
+    /// <summary>
+    /// Conversion functions for the WebMercator coordinate system
+    /// </summary>
     public static class WebMercatorHandler
     {
         // https://gist.github.com/nagasudhirpulla/9b5a192ccaca3c5992e5d4af0d1e6dc4
         
         private const int EarthRadius = 6378137;
         private const double OriginShift = 2 * Math.PI * EarthRadius / 2;
-        
-        //Converts given lat/lon in WGS84 Datum to XY in Spherical Mercator EPSG:900913
+
+        /// <summary>
+        /// Converts given lat/lon in WGS84 Datum to XY in Spherical Mercator EPSG:900913
+        /// </summary>
+        /// <param name="lat">Latitude of the point</param>
+        /// <param name="lon">Longitude of the point</param>
+        /// <returns>Point (x, y) in the Web Mercator coordinate system</returns>
         public static (double x, double y) LatLonToMeters(double lat, double lon)
         {
             double x = lon * OriginShift / 180;
@@ -17,12 +25,16 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles.WebMercator
             y = y * OriginShift / 180;
             return (x, y);
         }
-        
-        //Converts XY point from (Spherical) Web Mercator EPSG:3785 (unofficially EPSG:900913) to lat/lon in WGS84 Datum
+
+        /// <summary>
+        /// Converts XY point from (Spherical) Web Mercator EPSG:3857 (previously EPSG:3785, unofficially EPSG:900913) to lat/lon in WGS84 Datum
+        /// </summary>
+        /// <param name="m">Point (x, y) in the Web Mercator coordinate system</param>
+        /// <returns>Point (lat, lon) in the WGS84 coordinate system</returns>
         public static (double x, double y) MetersToLatLon((double x, double y) m)
         {
-            double x = (m.x / OriginShift) * 180;
-            double y = (m.y / OriginShift) * 180;
+            double x = m.x / OriginShift * 180;
+            double y = m.y / OriginShift * 180;
             y = 180 / Math.PI * (2 * Math.Atan(Math.Exp(y * Math.PI / 180)) - Math.PI / 2);
 
             //Clamp latitude value to acceptable range.
@@ -30,46 +42,136 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles.WebMercator
 
             return (x, y);
         }
-        
-        //Converts EPSG:3857 to pyramid pixel coordinates in given zoom level
-        public static (long x, long y) MetersToPixels((double x, double y) m, int zoom, int tileSize = 512)
+
+        /// <summary>
+        /// Converts EPSG:3857 to pyramid pixel coordinates in given zoom level
+        /// </summary>
+        /// <param name="m">Point (x, y) in the Web Mercator coordinate system</param>
+        /// <param name="zoom">Scale level at which the conversion to pixel coordinates is performed</param>
+        /// <param name="tileSize">Tile size. Used to determine the resolution</param>
+        /// <returns>Point (x, y) on the virtual raster of a specified resolution covering the entire world</returns>
+        [Obsolete("MetersToPixels is deprecated, please use FromMetersToPixels instead.")]
+        public static (double x, double y) MetersToPixels((double x, double y) m, int zoom, int tileSize = 512)
         {
             double res = Resolution(zoom, tileSize);
             return MetersToPixels(m, res);
         }
 
-        //Converts EPSG:3857 to pyramid pixel coordinates for given zoom level resolution. In this case zoomlevel resolution is precalculated for performance.
-        public static (long x, long y) MetersToPixels((double x, double y) m, double res)
+        /// <summary>
+        /// Converts EPSG:3857 to pyramid pixel coordinates in given zoom level
+        /// </summary>
+        /// <param name="m">Point (x, y) in the Web Mercator coordinate system</param>
+        /// <param name="zoom">Scale level at which the conversion to pixel coordinates is performed</param>
+        /// <param name="tileSize">Tile size. Used to determine the resolution</param>
+        /// <returns>Point (x, y) on the virtual raster of a specified resolution covering the entire world</returns>
+        /// <remarks>Pixel coordinates are truncated to integer values</remarks>
+        public static (long x, long y) FromMetersToPixels((double x, double y) m, int zoom, int tileSize = 512)
+        {
+            double res = Resolution(zoom, tileSize);
+            return FromMetersToPixels(m, res);
+        }
+
+        /// <summary>
+        /// Converts EPSG:3857 to pyramid pixel coordinates for given zoom level resolution. In this case zoomlevel resolution is precalculated for performance.
+        /// </summary>
+        /// <param name="m">Point (x, y) in the Web Mercator coordinate system</param>
+        /// <param name="res">Resolution</param>
+        /// <returns>Point (x, y) on the virtual raster of a specified resolution covering the entire world</returns>
+        [Obsolete("MetersToPixels is deprecated, please use FromMetersToPixels instead.")]
+        public static (double x, double y) MetersToPixels((double x, double y) m, double res)
+        {
+            double x = (m.x + OriginShift) / res;
+            double y = (m.y + OriginShift) / res;
+            return (x, y);
+        }
+
+        /// <summary>
+        /// Converts EPSG:3857 to pyramid pixel coordinates for given zoom level resolution. In this case zoomlevel resolution is precalculated for performance.
+        /// </summary>
+        /// <param name="m">Point (x, y) in the Web Mercator coordinate system</param>
+        /// <param name="res">Resolution</param>
+        /// <returns>Point (x, y) on the virtual raster of a specified resolution covering the entire world</returns>
+        /// <remarks>Pixel coordinates are truncated to integer values</remarks>
+        public static (long x, long y) FromMetersToPixels((double x, double y) m, double res)
         {
             long x = (long) ((m.x + OriginShift) / res);
             long y = (long) ((m.y + OriginShift) / res);
             return (x, y);
         }
 
-        //Converts pixel coordinates in given zoom level of pyramid to EPSG:3857
-        public static (double x, double y) PixelsToMeters((long x, long y) p, int zoom, int tileSize = 512)
+        /// <summary>
+        /// Converts pixel coordinates in given zoom level of pyramid to EPSG:3857
+        /// </summary>
+        /// <param name="p">Point (x, y) on the virtual raster of a specified resolution covering the entire world</param>
+        /// <param name="zoom">Scale level at which the conversion to pixel coordinates is performed</param>
+        /// <param name="tileSize">Tile size. Used to determine the resolution</param>
+        /// <returns>Point (x, y) in the Web Mercator coordinate system</returns>
+        [Obsolete("PixelsToMeters is deprecated, please use FromPixelsToMeters instead.")]
+        public static (double x, double y) PixelsToMeters((double x, double y) p, int zoom, int tileSize = 512)
         {
             double res = Resolution(zoom, tileSize);
             return PixelsToMeters(p, res);
         }
 
-        //Converts pixel coordinates in given zoom level resolution of pyramid to EPSG:3857. In this case zoomlevel resolution is precalculated for performan
-        public static (double x, double y) PixelsToMeters((long x, long y) p, double res)
+        /// <summary>
+        /// Converts pixel coordinates in given zoom level of pyramid to EPSG:3857
+        /// </summary>
+        /// <param name="p">Point (x, y) on the virtual raster of a specified resolution covering the entire world</param>
+        /// <param name="zoom">Scale level at which the conversion to pixel coordinates is performed</param>
+        /// <param name="tileSize">Tile size. Used to determine the resolution</param>
+        /// <returns>Point (x, y) in the Web Mercator coordinate system</returns>
+        public static (double x, double y) FromPixelsToMeters((long x, long y) p, int zoom, int tileSize = 512)
+        {
+            double res = Resolution(zoom, tileSize);
+            return FromPixelsToMeters(p, res);
+        }
+
+        /// <summary>
+        /// Converts pixel coordinates in given zoom level resolution of pyramid to EPSG:3857. In this case zoomlevel resolution is precalculated for performance.
+        /// </summary>
+        /// <param name="p">Point (x, y) on the virtual raster of a specified resolution covering the entire world</param>
+        /// <param name="res">Resolution</param>
+        /// <returns>Point (x, y) in the Web Mercator coordinate system</returns>
+        [Obsolete("PixelsToMeters is deprecated, please use FromPixelsToMeters instead.")]
+        public static (double x, double y) PixelsToMeters((double x, double y) p, double res)
         {
             double x = p.x * res - OriginShift;
             double y = p.y * res - OriginShift;
             return (x, y);
         }
 
-        //Resolution (meters/pixel) for given zoom level (measured at Equator)
-        public static double Resolution(int zoom, int tileSize = 512)
+        /// <summary>
+        /// Converts pixel coordinates in given zoom level resolution of pyramid to EPSG:3857. In this case zoomlevel resolution is precalculated for performance.
+        /// </summary>
+        /// <param name="p">Point (x, y) on the virtual raster of a specified resolution covering the entire world</param>
+        /// <param name="res">Resolution</param>
+        /// <returns>Point (x, y) in the Web Mercator coordinate system</returns>
+        public static (double x, double y) FromPixelsToMeters((long x, long y) p, double res)
         {
-            return InitialResolution(tileSize) / (double)(1 << zoom);// (Math.Pow(2, zoom));
+            double x = p.x * res - OriginShift;
+            double y = p.y * res - OriginShift;
+            return (x, y);
         }
 
+        /// <summary>
+        /// Resolution (meters/pixel) for given zoom level (measured at Equator)
+        /// </summary>
+        /// <param name="zoom">Zoom level</param>
+        /// <param name="tileSize">Tile size. Used to determine the resolution</param>
+        /// <returns>Resolution of the virtual raster</returns>
+        public static double Resolution(int zoom, int tileSize = 512)
+        {
+            return InitialResolution(tileSize) / (1 << zoom);// (Math.Pow(2, zoom));
+        }
+
+        /// <summary>
+        /// Resolution (meters/pixel) at the zero scale level of the pyramid (measured at Equator)
+        /// </summary>
+        /// <param name="tileSize">Tile size</param>
+        /// <returns>Resolution of the virtual raster at the zero scale level of the pyramid</returns>
         public static double InitialResolution(int tileSize = 512)
         {
-            return  2 * Math.PI * EarthRadius / (double)tileSize;
+            return 2 * Math.PI * EarthRadius / tileSize;
         }
     }
 }

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/WebMercator/WebMercatorHandler.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/WebMercator/WebMercatorHandler.cs
@@ -32,29 +32,29 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles.WebMercator
         }
         
         //Converts EPSG:3857 to pyramid pixel coordinates in given zoom level
-        public static (double x, double y) MetersToPixels((double x, double y) m, int zoom, int tileSize = 512)
+        public static (long x, long y) MetersToPixels((double x, double y) m, int zoom, int tileSize = 512)
         {
             double res = Resolution(zoom, tileSize);
             return MetersToPixels(m, res);
         }
 
         //Converts EPSG:3857 to pyramid pixel coordinates for given zoom level resolution. In this case zoomlevel resolution is precalculated for performance.
-        public static (double x, double y) MetersToPixels((double x, double y) m, double res)
+        public static (long x, long y) MetersToPixels((double x, double y) m, double res)
         {
-            double x = (m.x + OriginShift) / res;
-            double y = (m.y + OriginShift) / res;
+            long x = (long) ((m.x + OriginShift) / res);
+            long y = (long) ((m.y + OriginShift) / res);
             return (x, y);
         }
 
         //Converts pixel coordinates in given zoom level of pyramid to EPSG:3857
-        public static (double x, double y) PixelsToMeters((double x, double y) p, int zoom, int tileSize = 512)
+        public static (double x, double y) PixelsToMeters((long x, long y) p, int zoom, int tileSize = 512)
         {
             double res = Resolution(zoom, tileSize);
             return PixelsToMeters(p, res);
         }
 
         //Converts pixel coordinates in given zoom level resolution of pyramid to EPSG:3857. In this case zoomlevel resolution is precalculated for performan
-        public static (double x, double y) PixelsToMeters((double x, double y) p, double res)
+        public static (double x, double y) PixelsToMeters((long x, long y) p, double res)
         {
             double x = p.x * res - OriginShift;
             double y = p.y * res - OriginShift;

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/Mapbox/TileGeometryTransformTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/Mapbox/TileGeometryTransformTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Implementation;
 using NetTopologySuite.IO.VectorTiles.Mapbox;
@@ -35,7 +36,31 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Mapbox
             }), 0, ref x, ref y);
             
             Assert.Equal(2048, x);
-            Assert.Equal(3025, y);
+            Assert.Equal(3026, y);
+        }
+
+        [Fact]
+        public void FloatingPointError()
+        {
+            const double expectedLat = 49.13987159729003;
+            const double expectedLon = 52.55401993319131;
+
+            var tileGeometry = new TileGeometryTransform(new Tile(651, 335, 10), 4096);
+            int x = 0;
+            int y = 0;
+            tileGeometry.Transform(new CoordinateArraySequence(new Coordinate[]
+            {
+                new Coordinate(expectedLat, expectedLon),
+            }), 0, ref x, ref y);
+                
+            Assert.Equal(3177, x);
+            Assert.Equal(2732, y);
+
+            (double actualLat, double actualLon) = tileGeometry.TransformInverse(x, y);
+
+            // comparing only 5 decimal places
+            Assert.Equal(expectedLat, actualLat, 5);
+            Assert.Equal(expectedLon, actualLon, 5);
         }
     }
 }

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripBase.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripBase.cs
@@ -103,8 +103,14 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
             double error = 2 * System.Math.Sqrt(pixelDiff * pixelDiff * 2) / Extent;
             if (expected is IPuntal)
             {
-                double test = expected.Distance(parsed);
-                Assert.True(test < error);
+                // In MultiPoint case check all points that forms it
+                for (int i = 0; i < expected.NumGeometries; i++)
+                {
+                    var expectedPoint = (Point)expected.GetGeometryN(i);
+                    var parsedPoint = (Point)parsed.GetGeometryN(i);
+                    double test = expectedPoint.Distance(parsedPoint);
+                    Assert.True(test < error);
+                }
             }
             else
                 Assert.True(new HausdorffSimilarityMeasure().Measure(expected, parsed) > 1 - error);

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripBase.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripBase.cs
@@ -96,6 +96,9 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
             // Points checked
             Assert.Equal(expected.OgcGeometryType, parsed.OgcGeometryType);
 
+            // Coordinates count checked
+            Assert.Equal(expected.Coordinates.Length, parsed.Coordinates.Length);
+
             double pixelDiff = (85.5 * 2);
             double error = 2 * System.Math.Sqrt(pixelDiff * pixelDiff * 2) / Extent;
             if (expected is IPuntal)

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripTests.cs
@@ -142,6 +142,20 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
         }
 
         [Fact]
+        public void test_encode_multipoint_point_outside_extent()
+        {
+            AssertRoundTrip("MULTIPOINT((10 10), (20 20), (185 40), (30 10))",
+                "{\"type\": \"MultiPoint\",\"coordinates\": [[10, 10], [20, 20], [30, 10]]}");
+        }
+
+        [Fact]
+        public void test_encode_multipoint_first_point_outside_extent()
+        {
+            AssertRoundTrip("MULTIPOINT((185 40), (10 10), (20 20), (30 10))",
+                "{\"type\": \"MultiPoint\",\"coordinates\": [[185, 40], [10, 10], [20, 20], [30, 10]]}");
+        }
+
+        [Fact]
         public void test_encode_multilinestring()
         {
             AssertRoundTrip("MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10))",

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripTests.cs
@@ -7,7 +7,13 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
         [Fact]
         public void test_encoder()
         {
-            AssertRoundTrip("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))");
+            AssertRoundTrip("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
+        }
+
+        [Fact]
+        public void test_encoder_smaller_one_pixel()
+        {
+            AssertRoundTripEmptyTile("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))");
         }
 
         [Fact]
@@ -130,8 +136,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
         [Fact]
         public void test_encode_polygon_reverse_winding_order()
         {
-            AssertRoundTrip("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
-                "{\"type\": \"Polygon\",\"coordinates\": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]}");
+            AssertRoundTrip("POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))");
         }
 
         [Fact]

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/RoundTripTests.cs
@@ -7,13 +7,13 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
         [Fact]
         public void test_encoder()
         {
-            AssertRoundTrip("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))");
+            AssertRoundTrip("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))");
         }
 
         [Fact]
         public void test_encoder_smaller_one_pixel()
         {
-            AssertRoundTripEmptyTile("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))");
+            AssertRoundTripEmptyTile("POLYGON ((0 0, 0.1 0, 0.1 0.1, 0 0.1, 0 0))");
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tests
         [Fact]
         public void test_encode_polygon_reverse_winding_order()
         {
-            AssertRoundTrip("POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))");
+            AssertRoundTrip("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))");
         }
 
         [Fact]

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/WebMercator/WebMercatorHandlerTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/WebMercator/WebMercatorHandlerTests.cs
@@ -13,20 +13,20 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers.WebMercator
             Assert.Equal(6446275.8410171578, meters.y);
 
             var pixels = WebMercatorHandler.MetersToPixels(meters, 0, 1024);
-            Assert.Equal(523.37777777777785, pixels.x);
-            Assert.Equal(676.71575078787225, pixels.y);
+            Assert.Equal(523, pixels.x);
+            Assert.Equal(676, pixels.y);
 
             pixels = WebMercatorHandler.MetersToPixels(meters, 1, 1024);
-            Assert.Equal(1046.7555555555557, pixels.x);
-            Assert.Equal(1353.4315015757445, pixels.y);
+            Assert.Equal(1046, pixels.x);
+            Assert.Equal(1353, pixels.y);
 
             pixels = WebMercatorHandler.MetersToPixels(meters, 2, 1024);
-            Assert.Equal(2093.5111111111114, pixels.x);
-            Assert.Equal(2706.863003151489, pixels.y);
+            Assert.Equal(2093, pixels.x);
+            Assert.Equal(2706, pixels.y);
 
             pixels = WebMercatorHandler.MetersToPixels(meters, 3, 1024);
-            Assert.Equal(4187.0222222222228, pixels.x);
-            Assert.Equal(5413.726006302978, pixels.y);
+            Assert.Equal(4187, pixels.x);
+            Assert.Equal(5413, pixels.y);
         }
 
         [Fact]

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/WebMercator/WebMercatorHandlerTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/Tilers/WebMercator/WebMercatorHandlerTests.cs
@@ -12,19 +12,19 @@ namespace NetTopologySuite.IO.VectorTiles.Tests.Tilers.WebMercator
             Assert.Equal(445277.96317309432, meters.x);
             Assert.Equal(6446275.8410171578, meters.y);
 
-            var pixels = WebMercatorHandler.MetersToPixels(meters, 0, 1024);
+            var pixels = WebMercatorHandler.FromMetersToPixels(meters, 0, 1024);
             Assert.Equal(523, pixels.x);
             Assert.Equal(676, pixels.y);
 
-            pixels = WebMercatorHandler.MetersToPixels(meters, 1, 1024);
+            pixels = WebMercatorHandler.FromMetersToPixels(meters, 1, 1024);
             Assert.Equal(1046, pixels.x);
             Assert.Equal(1353, pixels.y);
 
-            pixels = WebMercatorHandler.MetersToPixels(meters, 2, 1024);
+            pixels = WebMercatorHandler.FromMetersToPixels(meters, 2, 1024);
             Assert.Equal(2093, pixels.x);
             Assert.Equal(2706, pixels.y);
 
-            pixels = WebMercatorHandler.MetersToPixels(meters, 3, 1024);
+            pixels = WebMercatorHandler.FromMetersToPixels(meters, 3, 1024);
             Assert.Equal(4187, pixels.x);
             Assert.Equal(5413, pixels.y);
         }


### PR DESCRIPTION
I found a problem when converting some objects. 
When reading objects through ```MapboxTileReader``` written through ```MapboxTileWriter```, some objects may become invalid.
The tile cannot be read with the error "No shell defined" in the reader.
After much research, I found that the numbers were incorrectly rounded when recalculating from "global" tile coordinates to "local" ones.
This led to the fact that some complex objects could have self-intersections after ```MapboxTileWriter```, which would lead to an incorrect definition of 
the winding order and, as a result, to the above error.

The problem was found in the following code:
https://github.com/NetTopologySuite/NetTopologySuite.IO.VectorTiles/blob/b75d308e1d5ba35683a7d7ec29273526696f6984/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs#L68

In the test, the global tile coordinates were equal to (2669673, 2819412.0000000005)
Calculating the local coordinates inside the tile by subtraction resulted in a shift of one pixel due to .0000000005.

To get rid of this problem, it was possible to add another type conversion and truncate tile coordinates.
It would look like this:
```C#
int localX = (int) ((long)pixels.x - _left);
int localY = (int) (_top - (long)pixels.y);
```

Since it all looks very strange (double -> long -> int), I decided to redo the methods for calculating tile coordinates so that they immediately 
return integer values.

Also moved the ```IsGreaterThanOnePixelOfTile``` method. It should also have given incorrect results, since the tile size was always 512