### PR TITLE
Improve perf when writing MBTiles

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -117,9 +117,12 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                     object id = localLayerFeature.Attributes.GetOptionalValue(idAttributeName);
 
                     //Converting ID to string, then trying to parse. This will handle situations will ignore situations where the ID value is not actually an integer or ulong number.
-                    if (id != null && ulong.TryParse(id.ToString(), out ulong idVal))
+                    if (id != null)
                     {
-                        feature.Id = idVal;
+                        if (id is ulong idu)
+                            feature.Id = idu;
+                        else if (ulong.TryParse(id.ToString(), out ulong idVal))
+                            feature.Id = idVal;
                     }
 
                     // Add feature to layer


### PR DESCRIPTION
We have an internal application where writing MBTiles is the performance bottleneck, making these changes gave us some meaningful improvements.

1) Instead of having each Encode method return a new list (or yielding results) and then adding them to the Geometry using AddRange, pass in the Geometry list and add the contents directly.
This gives us a ~12% performance increase in our internal testing.

2) If id is a ulong, set it directly instead of ToString and Parse it. Another small performance improvement.