### PR TITLE
Add possibility to convert tiles to other coordinates than WGS84

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/ITileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/ITileGeometryTransform.cs
@@ -7,7 +7,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
     /// <summary>
     /// A transformation utility from WGS84 coordinates to a local tile coordinate system in pixel
     /// </summary>
-    internal interface ITileGeometryTransform
+    public interface ITileGeometryTransform
     {
         /// <summary>
         /// The zoom level pixel resolution based on the extent.

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/ITileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/ITileGeometryTransform.cs
@@ -1,0 +1,54 @@
+using NetTopologySuite.Geometries;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NetTopologySuite.IO.VectorTiles.Tests")]
+namespace NetTopologySuite.IO.VectorTiles.Mapbox
+{
+    /// <summary>
+    /// A transformation utility from WGS84 coordinates to a local tile coordinate system in pixel
+    /// </summary>
+    internal interface ITileGeometryTransform
+    {
+        /// <summary>
+        /// The zoom level pixel resolution based on the extent.
+        /// </summary>
+        double ZoomResolution { get; }
+
+        /// <summary>
+        /// Transforms the coordinate at <paramref name="index"/> of <paramref name="sequence"/> to the tile coordinate system.
+        /// The return value is the position relative to the local point at (<paramref name="currentX"/>, <paramref name="currentY"/>).
+        /// </summary>
+        /// <param name="sequence">The input sequence</param>
+        /// <param name="index">The index of the coordinate to transform</param>
+        /// <param name="currentX">The current horizontal component of the cursor location. This value is updated.</param>
+        /// <param name="currentY">The current vertical component of the cursor location. This value is updated.</param>
+        /// <returns>The position relative to the local point at (<paramref name="currentX"/>, <paramref name="currentY"/>).</returns>
+        (int x, int y) Transform(CoordinateSequence sequence, int index, ref int currentX, ref int currentY);
+
+        /// <summary>
+        /// Transforms the point in the local tile pixel coordinates into WGS84 coordinates.
+        /// The return value is longitude and latitude of the tile pixel point (<paramref name="x"/>, <paramref name="y"/>).
+        /// </summary>
+        /// <param name="x">The horizontal component of the point in the tile coordinate system</param>
+        /// <param name="y">The vertical component of the point in the tile coordinate system</param>
+        /// <returns>WGS84 coordinates of the point in tile "pixel" coordinates (<paramref name="x"/>, <paramref name="y"/>).</returns>
+        (double longitude, double latitude) TransformInverse(int x, int y);
+
+        /// <summary>
+        /// Check if the point with tile coordinates (<paramref name="x"/>, <paramref name="y"/> lies inside tile extent
+        /// </summary>
+        /// <param name="x">Horizontal component of the point in the tile coordinate system</param>
+        /// <param name="y">Vertical component of the point in the tile coordinate system</param>
+        /// <returns>true if point lies inside tile extent</returns>
+        bool IsPointInExtent(int x, int y);
+
+        /// <summary>
+        /// Checks to see if a geometries envelope is greater than 1 square pixel in size for a specified zoom level.
+        /// </summary>
+        /// <param name="polygon">Polygon to test.</param>
+        /// <returns>true if the <paramref name="polygon"/> is greater than 1 pixel in the tile pixel coordinates</returns>
+        bool IsGreaterThanOnePixelOfTile(Geometry geometry);
+
+        (long x, long y) ExtentInPixel(Envelope env);
+    }
+}

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
@@ -50,11 +50,11 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             {
                 Debug.Assert(mbTileLayer.Version == 2U);
 
-                var tgs = tgtFactory == null ? new TileGeometryTransform(tileDefinition, mbTileLayer.Extent) : tgtFactory(tileDefinition, mbTileLayer.Extent);
+                var tgt = tgtFactory == null ? new TileGeometryTransform(tileDefinition, mbTileLayer.Extent) : tgtFactory(tileDefinition, mbTileLayer.Extent);
                 var layer = new Layer {Name = mbTileLayer.Name};
                 foreach (var mbTileFeature in mbTileLayer.Features)
                 {
-                    var feature = ReadFeature(tgs, mbTileLayer, mbTileFeature, idAttributeName);
+                    var feature = ReadFeature(tgt, mbTileLayer, mbTileFeature, idAttributeName);
                     layer.Features.Add(feature);
                 }
                 vectorTile.Layers.Add(layer);
@@ -63,9 +63,9 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return vectorTile;
         }
 
-        private IFeature ReadFeature(ITileGeometryTransform tgs, Tile.Layer mbTileLayer, Tile.Feature mbTileFeature, string idAttributeName)
+        private IFeature ReadFeature(ITileGeometryTransform tgt, Tile.Layer mbTileLayer, Tile.Feature mbTileFeature, string idAttributeName)
         {
-            var geometry = ReadGeometry(tgs, mbTileFeature.Type, mbTileFeature.Geometry);
+            var geometry = ReadGeometry(tgt, mbTileFeature.Type, mbTileFeature.Geometry);
             var attributes = ReadAttributeTable(mbTileFeature, mbTileLayer.Keys, mbTileLayer.Values);
 
             //Check to see if an id value is already captured in the attributes, if not, add it.
@@ -78,41 +78,41 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return new Feature(geometry, attributes);
         }
 
-        private Geometry ReadGeometry(ITileGeometryTransform tgs, Tile.GeomType type, IList<uint> geometry)
+        private Geometry ReadGeometry(ITileGeometryTransform tgt, Tile.GeomType type, IList<uint> geometry)
         {
             switch (type)
             {
                 case Tile.GeomType.Point:
-                    return ReadPoint(tgs, geometry);
+                    return ReadPoint(tgt, geometry);
 
                 case Tile.GeomType.LineString:
-                    return ReadLineString(tgs, geometry);
+                    return ReadLineString(tgt, geometry);
 
                 case Tile.GeomType.Polygon:
-                    return ReadPolygon(tgs, geometry);
+                    return ReadPolygon(tgt, geometry);
             }
 
             return null;
         }
 
-        private Geometry ReadPoint(ITileGeometryTransform tgs, IList<uint> geometry)
+        private Geometry ReadPoint(ITileGeometryTransform tgt, IList<uint> geometry)
         {
             int currentIndex = 0; int currentX = 0; int currentY = 0;
-            var sequences = ReadCoordinateSequences(tgs, geometry, ref currentIndex, ref currentX, ref currentY, forPoint:true);
+            var sequences = ReadCoordinateSequences(tgt, geometry, ref currentIndex, ref currentX, ref currentY, forPoint:true);
             return CreatePuntal(sequences);
         }
 
-        private Geometry ReadLineString(ITileGeometryTransform tgs, IList<uint> geometry)
+        private Geometry ReadLineString(ITileGeometryTransform tgt, IList<uint> geometry)
         {
             int currentIndex = 0; int currentX = 0; int currentY = 0;
-            var sequences = ReadCoordinateSequences(tgs, geometry, ref currentIndex, ref currentX, ref currentY);
+            var sequences = ReadCoordinateSequences(tgt, geometry, ref currentIndex, ref currentX, ref currentY);
             return CreateLineal(sequences);
         }
 
-        private Geometry ReadPolygon(ITileGeometryTransform tgs, IList<uint> geometry)
+        private Geometry ReadPolygon(ITileGeometryTransform tgt, IList<uint> geometry)
         {
             int currentIndex = 0; int currentX = 0; int currentY = 0;
-            var sequences = ReadCoordinateSequences(tgs, geometry, ref currentIndex, ref currentX, ref currentY, 1);
+            var sequences = ReadCoordinateSequences(tgt, geometry, ref currentIndex, ref currentX, ref currentY, 1);
             return CreatePolygonal(sequences);
         }
 
@@ -201,7 +201,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         }
 
         private CoordinateSequence[] ReadCoordinateSequences(
-            ITileGeometryTransform tgs, IList<uint> geometry,
+            ITileGeometryTransform tgt, IList<uint> geometry,
             ref int currentIndex, ref int currentX, ref int currentY, int buffer = 0, bool forPoint = false)
         {
             (var command, int count) = ParseCommandInteger(geometry[currentIndex]);
@@ -209,7 +209,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             if (count > 1)
             {
                 currentIndex++;
-                return ReadSinglePointSequences(tgs, geometry, count, ref currentIndex, ref currentX, ref currentY);
+                return ReadSinglePointSequences(tgt, geometry, count, ref currentIndex, ref currentX, ref currentY);
             }
 
             var sequences = new List<CoordinateSequence>();
@@ -237,13 +237,13 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 // Create sequence, add starting point
                 var sequence = _factory.CoordinateSequenceFactory.Create(1 + count + buffer, 2);
                 int sequenceIndex = 0;
-                TransformOffsetAndAddToSequence(tgs, currentPosition, sequence, sequenceIndex++);
+                TransformOffsetAndAddToSequence(tgt, currentPosition, sequence, sequenceIndex++);
 
                 // Read and add offsets
                 for (int i = 1; i <= count; i++)
                 {
                     currentPosition = ParseOffset(currentPosition, geometry, ref currentIndex);
-                    TransformOffsetAndAddToSequence(tgs, currentPosition, sequence, sequenceIndex++);
+                    TransformOffsetAndAddToSequence(tgt, currentPosition, sequence, sequenceIndex++);
                 }
 
                 // Check for ClosePath command
@@ -273,7 +273,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return sequences.ToArray();
         }
 
-        private CoordinateSequence[] ReadSinglePointSequences(ITileGeometryTransform tgs, IList<uint> geometry,
+        private CoordinateSequence[] ReadSinglePointSequences(ITileGeometryTransform tgt, IList<uint> geometry,
             int numSequences, ref int currentIndex, ref int currentX, ref int currentY)
         {
             var res = new CoordinateSequence[numSequences];
@@ -283,7 +283,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 res[i] = _factory.CoordinateSequenceFactory.Create(1, 2);
 
                 currentPosition = ParseOffset(currentPosition, geometry, ref currentIndex);
-                TransformOffsetAndAddToSequence(tgs, currentPosition, res[i], 0);
+                TransformOffsetAndAddToSequence(tgt, currentPosition, res[i], 0);
             }
 
             currentX = currentPosition.currentX;
@@ -291,9 +291,9 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return res;
         }
 
-        private void TransformOffsetAndAddToSequence(ITileGeometryTransform tgs, (int x, int y) localPosition, CoordinateSequence sequence, int index)
+        private void TransformOffsetAndAddToSequence(ITileGeometryTransform tgt, (int x, int y) localPosition, CoordinateSequence sequence, int index)
         {
-            var (longitude, latitude) = tgs.TransformInverse(localPosition.x, localPosition.y);
+            var (longitude, latitude) = tgt.TransformInverse(localPosition.x, localPosition.y);
             sequence.SetOrdinate(index, Ordinate.X, longitude);
             sequence.SetOrdinate(index, Ordinate.Y, latitude);
         }

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
@@ -32,9 +32,9 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="stream">Vector tile stream.</param>
         /// <param name="tileDefinition">Tile information.</param>
         /// <returns></returns>
-        public VectorTile Read(Stream stream, Tiles.Tile tileDefinition, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
+        public VectorTile Read(Stream stream, Tiles.Tile tileDefinition)
         {
-            return Read(stream, tileDefinition, null, tgtFactory);
+            return Read(stream, tileDefinition, null);
         }
 
         /// <summary>

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
@@ -66,7 +66,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return vectorTile;
         }
 
-        private IFeature ReadFeature(TileGeometryTransform tgs, Tile.Layer mbTileLayer, Tile.Feature mbTileFeature, string idAttributeName)
+        private IFeature ReadFeature(ITileGeometryTransform tgs, Tile.Layer mbTileLayer, Tile.Feature mbTileFeature, string idAttributeName)
         {
             var geometry = ReadGeometry(tgs, mbTileFeature.Type, mbTileFeature.Geometry);
             var attributes = ReadAttributeTable(mbTileFeature, mbTileLayer.Keys, mbTileLayer.Values);
@@ -81,7 +81,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return new Feature(geometry, attributes);
         }
 
-        private Geometry ReadGeometry(TileGeometryTransform tgs, Tile.GeomType type, IList<uint> geometry)
+        private Geometry ReadGeometry(ITileGeometryTransform tgs, Tile.GeomType type, IList<uint> geometry)
         {
             switch (type)
             {
@@ -98,21 +98,21 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return null;
         }
 
-        private Geometry ReadPoint(TileGeometryTransform tgs, IList<uint> geometry)
+        private Geometry ReadPoint(ITileGeometryTransform tgs, IList<uint> geometry)
         {
             int currentIndex = 0; int currentX = 0; int currentY = 0;
             var sequences = ReadCoordinateSequences(tgs, geometry, ref currentIndex, ref currentX, ref currentY, forPoint:true);
             return CreatePuntal(sequences);
         }
 
-        private Geometry ReadLineString(TileGeometryTransform tgs, IList<uint> geometry)
+        private Geometry ReadLineString(ITileGeometryTransform tgs, IList<uint> geometry)
         {
             int currentIndex = 0; int currentX = 0; int currentY = 0;
             var sequences = ReadCoordinateSequences(tgs, geometry, ref currentIndex, ref currentX, ref currentY);
             return CreateLineal(sequences);
         }
 
-        private Geometry ReadPolygon(TileGeometryTransform tgs, IList<uint> geometry)
+        private Geometry ReadPolygon(ITileGeometryTransform tgs, IList<uint> geometry)
         {
             int currentIndex = 0; int currentX = 0; int currentY = 0;
             var sequences = ReadCoordinateSequences(tgs, geometry, ref currentIndex, ref currentX, ref currentY, 1);
@@ -204,7 +204,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         }
 
         private CoordinateSequence[] ReadCoordinateSequences(
-            TileGeometryTransform tgs, IList<uint> geometry,
+            ITileGeometryTransform tgs, IList<uint> geometry,
             ref int currentIndex, ref int currentX, ref int currentY, int buffer = 0, bool forPoint = false)
         {
             (var command, int count) = ParseCommandInteger(geometry[currentIndex]);
@@ -276,7 +276,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return sequences.ToArray();
         }
 
-        private CoordinateSequence[] ReadSinglePointSequences(TileGeometryTransform tgs, IList<uint> geometry,
+        private CoordinateSequence[] ReadSinglePointSequences(ITileGeometryTransform tgs, IList<uint> geometry,
             int numSequences, ref int currentIndex, ref int currentX, ref int currentY)
         {
             var res = new CoordinateSequence[numSequences];
@@ -294,7 +294,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return res;
         }
 
-        private void TransformOffsetAndAddToSequence(TileGeometryTransform tgs, (int x, int y) localPosition, CoordinateSequence sequence, int index)
+        private void TransformOffsetAndAddToSequence(ITileGeometryTransform tgs, (int x, int y) localPosition, CoordinateSequence sequence, int index)
         {
             var (longitude, latitude) = tgs.TransformInverse(localPosition.x, localPosition.y);
             sequence.SetOrdinate(index, Ordinate.X, longitude);

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Xml.Linq;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 
@@ -9,8 +10,6 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
 {
     public class MapboxTileReader
     {
-
-
         private readonly GeometryFactory _factory;
 
         public MapboxTileReader()
@@ -29,9 +28,9 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="stream">Vector tile stream.</param>
         /// <param name="tileDefinition">Tile information.</param>
         /// <returns></returns>
-        public VectorTile Read(Stream stream, Tiles.Tile tileDefinition)
+        public VectorTile Read(Stream stream, Tiles.Tile tileDefinition, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
         {
-            return Read(stream, tileDefinition, null);
+            return Read(stream, tileDefinition, null, tgtFactory);
         }
 
         /// <summary>
@@ -41,10 +40,8 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="tileDefinition">Tile information.</param>
         /// <param name="idAttributeName">Optional. Specifies the name of the attribute that the vector tile feature's ID should be stored in the NetTopologySuite Features AttributeTable.</param>
         /// <returns></returns>
-        public VectorTile Read(Stream stream, Tiles.Tile tileDefinition, string idAttributeName)
+        public VectorTile Read(Stream stream, Tiles.Tile tileDefinition, string idAttributeName, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
         {
-
-
             // Deserialize the tile
             var tile = ProtoBuf.Serializer.Deserialize<Mapbox.Tile>(stream);
 
@@ -53,7 +50,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             {
                 Debug.Assert(mbTileLayer.Version == 2U);
 
-                var tgs = new TileGeometryTransform(tileDefinition, mbTileLayer.Extent);
+                var tgs = tgtFactory == null ? new TileGeometryTransform(tileDefinition, mbTileLayer.Extent) : tgtFactory(tileDefinition, mbTileLayer.Extent);
                 var layer = new Layer {Name = mbTileLayer.Name};
                 foreach (var mbTileFeature in mbTileLayer.Features)
                 {

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileReader.cs
@@ -1,16 +1,20 @@
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Xml.Linq;
-using NetTopologySuite.Features;
-using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.IO.VectorTiles.Mapbox
 {
     public class MapboxTileReader
     {
         private readonly GeometryFactory _factory;
+
+        /// <summary>
+        /// The default attribute name of a feature's identifier
+        /// </summary>
+        public const string DefaultIdAttributeName = "id";
 
         public MapboxTileReader()
             : this(new GeometryFactory(new PrecisionModel(), 4326))
@@ -40,7 +44,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="tileDefinition">Tile information.</param>
         /// <param name="idAttributeName">Optional. Specifies the name of the attribute that the vector tile feature's ID should be stored in the NetTopologySuite Features AttributeTable.</param>
         /// <returns></returns>
-        public VectorTile Read(Stream stream, Tiles.Tile tileDefinition, string idAttributeName, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
+        public VectorTile Read(Stream stream, Tiles.Tile tileDefinition, string idAttributeName = DefaultIdAttributeName, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
         {
             // Deserialize the tile
             var tile = ProtoBuf.Serializer.Deserialize<Mapbox.Tile>(stream);

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -30,10 +30,11 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="tree">The tree.</param>
         /// <param name="path">The path.</param>
         /// <param name="extent">The extent.</param>
+        /// <param name="tgtFactory">Function creating a tile geometry transformation object.</param>
         /// <remarks>Replaces the files if they are already present.</remarks>
         [Obsolete("Use overload that can specify minLineal- and minPolygonalExtent")]
-        public static void Write(this VectorTileTree tree, string path, uint extent = 4096)
-            => Write(tree, path, DefaultMinLinealExtent, DefaultMinPolygonalExtent, extent, DefaultIdAttributeName);
+        public static void Write(this VectorTileTree tree, string path, uint extent = 4096, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
+            => Write(tree, path, DefaultMinLinealExtent, DefaultMinPolygonalExtent, extent, DefaultIdAttributeName, tgtFactory);
 
         /// <summary>
         /// Writes the tiles in a /z/x/y.mvt folder structure.
@@ -43,9 +44,10 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="minLinealExtent">The minimum length in pixel one of a lineal feature's extent edges has to have in order for the feature to be written. The default is 1.</param>
         /// <param name="minPolygonalExtent">The minimum area in pixel one of a polygonal feature's extent has to have in order for the feature to be written. The default is 2.</param>
         /// <param name="extent">The extent.</param>
+        /// <param name="tgtFactory">Function creating a tile geometry transformation object.</param>
         /// <remarks>Replaces the files if they are already present.</remarks>
         public static void Write(this VectorTileTree tree, string path, uint minLinealExtent, uint minPolygonalExtent,
-            uint extent = 4096, string idAttributeName = DefaultIdAttributeName)
+            uint extent = 4096, string idAttributeName = DefaultIdAttributeName, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
         {
             IEnumerable<VectorTile> GetTiles()
             {
@@ -55,7 +57,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 }
             }
 
-            GetTiles().Write(path, minLinealExtent, minPolygonalExtent, extent, idAttributeName);
+            GetTiles().Write(path, minLinealExtent, minPolygonalExtent, extent, idAttributeName, tgtFactory);
         }
 
         /// <summary>
@@ -64,10 +66,11 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="vectorTiles">The tiles.</param>
         /// <param name="path">The path.</param>
         /// <param name="extent">The extent.</param>
+        /// <param name="tgtFactory">Function creating a tile geometry transformation object.</param>
         /// <remarks>Replaces the files if they are already present.</remarks>
         [Obsolete("Use overload that can specify minLineal- and minPolygonalExtent")]
-        public static void Write(this IEnumerable<VectorTile> vectorTiles, string path, uint extent = 4096)
-            => Write(vectorTiles, path, DefaultMinLinealExtent, DefaultMinPolygonalExtent, extent, DefaultIdAttributeName);
+        public static void Write(this IEnumerable<VectorTile> vectorTiles, string path, uint extent = 4096, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
+            => Write(vectorTiles, path, DefaultMinLinealExtent, DefaultMinPolygonalExtent, extent, DefaultIdAttributeName, tgtFactory);
 
         /// <summary>
         /// Writes the tiles in a /z/x/y.mvt folder structure.
@@ -77,9 +80,10 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="minLinealExtent">The minimum length in pixel one of a lineal feature's extent edges has to have in order for the feature to be written. The default is 1.</param>
         /// <param name="minPolygonalExtent">The minimum area in pixel one of a polygonal feature's extent has to have in order for the feature to be written. The default is 2.</param>
         /// <param name="extent">The extent.</param>
+        /// <param name="tgtFactory">Function creating a tile geometry transformation object.</param>
         /// <remarks>Replaces the files if they are already present.</remarks>
         public static void Write(this IEnumerable<VectorTile> vectorTiles, string path, uint minLinealExtent, uint minPolygonalExtent,
-            uint extent = 4096, string idAttributeName = DefaultIdAttributeName)
+            uint extent = 4096, string idAttributeName = DefaultIdAttributeName, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
         {
             foreach (var vectorTile in vectorTiles)
             {
@@ -97,7 +101,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
                 string file = Path.Combine(xFolder, $"{tile.Y}.mvt");
 
                 using var stream = File.Open(file, FileMode.Create);
-                vectorTile.Write(stream, minLinealExtent, minPolygonalExtent, extent, idAttributeName);
+                vectorTile.Write(stream, minLinealExtent, minPolygonalExtent, extent, idAttributeName, tgtFactory);
             }
         }
 
@@ -108,9 +112,10 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="stream">The stream to write to.</param>
         /// <param name="extent">The extent.</param>
         /// <param name="idAttributeName">The name of an attribute property to use as the ID for the Feature. Vector tile feature ID's should be integer or ulong numbers.</param>
+        /// <param name="tgtFactory">Function creating a tile geometry transformation object.</param>
         [Obsolete("Use overload that can specify minLineal- and minPolygonalExtent")]
-        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096, string idAttributeName = "id")
-            => Write(vectorTile, stream, DefaultMinLinealExtent, DefaultMinPolygonalExtent, extent, idAttributeName);
+        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096, string idAttributeName = "id", Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
+            => Write(vectorTile, stream, DefaultMinLinealExtent, DefaultMinPolygonalExtent, extent, idAttributeName, tgtFactory);
 
         /// <summary>
         /// Writes the tile to the given stream.
@@ -121,16 +126,17 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="minPolygonalExtent">The minimum area in pixel one of a polygonal feature's extent has to have in order for the feature to be written. The default is 2.</param>
         /// <param name="extent">The extent.</param>
         /// <param name="idAttributeName">The name of an attribute property to use as the ID for the Feature. Vector tile feature ID's should be integer or ulong numbers.</param>
+        /// <param name="tgtFactory">Function creating a tile geometry transformation object.</param>
         public static void Write(this VectorTile vectorTile, Stream stream, uint minLinealExtent, uint minPolygonalExtent,
-            uint extent = 4096, string idAttributeName = "id")
+            uint extent = 4096, string idAttributeName = "id", Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
         {
             // ensure valid minimal polygonal extent
             if (minPolygonalExtent < 1) minPolygonalExtent = 1;
 
             var tile = new Tiles.Tile(vectorTile.TileId);
-            var tgt = new TileGeometryTransform(tile, extent);
+            var tgt = tgtFactory == null ? new TileGeometryTransform(tile, extent) : tgtFactory(tile, extent);
 
-            var mapboxTile = new Mapbox.Tile();
+                var mapboxTile = new Mapbox.Tile();
             foreach (var localLayer in vectorTile.Layers)
             {
                 var layer = new Mapbox.Tile.Layer { Version = 2, Name = localLayer.Name, Extent = extent };

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -114,7 +114,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="idAttributeName">The name of an attribute property to use as the ID for the Feature. Vector tile feature ID's should be integer or ulong numbers.</param>
         /// <param name="tgtFactory">Function creating a tile geometry transformation object.</param>
         [Obsolete("Use overload that can specify minLineal- and minPolygonalExtent")]
-        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096, string idAttributeName = "id", Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
+        public static void Write(this VectorTile vectorTile, Stream stream, uint extent = 4096, string idAttributeName = DefaultIdAttributeName, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
             => Write(vectorTile, stream, DefaultMinLinealExtent, DefaultMinPolygonalExtent, extent, idAttributeName, tgtFactory);
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         /// <param name="idAttributeName">The name of an attribute property to use as the ID for the Feature. Vector tile feature ID's should be integer or ulong numbers.</param>
         /// <param name="tgtFactory">Function creating a tile geometry transformation object.</param>
         public static void Write(this VectorTile vectorTile, Stream stream, uint minLinealExtent, uint minPolygonalExtent,
-            uint extent = 4096, string idAttributeName = "id", Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
+            uint extent = 4096, string idAttributeName = DefaultIdAttributeName, Func<Tiles.Tile, uint, ITileGeometryTransform> tgtFactory = null)
         {
             // ensure valid minimal polygonal extent
             if (minPolygonalExtent < 1) minPolygonalExtent = 1;

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/MapboxTileWriter.cs
@@ -259,7 +259,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             return null;
         }
 
-        private static void EncodeTo(List<uint> destination, IPuntal puntal, TileGeometryTransform tgt)
+        private static void EncodeTo(List<uint> destination, IPuntal puntal, ITileGeometryTransform tgt)
         {
             const int CoordinateIndex = 0;
 
@@ -296,7 +296,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             destination[moveToIndex] = GenerateCommandInteger(MapboxCommandType.MoveTo, (destination.Count - moveToIndex) / 2);
         }
 
-        private static void EncodeTo(List<uint> destination, ILineal lineal, uint minLinealExtent, TileGeometryTransform tgt)
+        private static void EncodeTo(List<uint> destination, ILineal lineal, uint minLinealExtent, ITileGeometryTransform tgt)
         {
             bool HasValidLength((long x, long y) tpl) 
                 => tpl.x >= minLinealExtent || tpl.y >= minLinealExtent;
@@ -311,7 +311,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             }
         }
 
-        private static void EncodeTo(List<uint> destination, IPolygonal polygonal, uint minPolygonalExtent, TileGeometryTransform tgt)
+        private static void EncodeTo(List<uint> destination, IPolygonal polygonal, uint minPolygonalExtent, ITileGeometryTransform tgt)
         {
             bool HasValidExtent((long x, long y) tpl)
                 => (tpl.x >= minPolygonalExtent && tpl.y > 0) ||
@@ -344,7 +344,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
             }
         }
 
-        private static void EncodeTo(List<uint> destination, CoordinateSequence sequence, TileGeometryTransform tgt,
+        private static void EncodeTo(List<uint> destination, CoordinateSequence sequence, ITileGeometryTransform tgt,
             ref int currentX, ref int currentY,
             bool ring = false, bool ccw = false)
         {

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -9,7 +9,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
     /// <summary>
     /// A transformation utility from WGS84 coordinates to a local tile coordinate system in pixel
     /// </summary>
-    internal struct TileGeometryTransform
+    internal struct TileGeometryTransform : ITileGeometryTransform
     {
         private readonly Tiles.Tile _tile;
         private readonly uint _extent;

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransform.cs
@@ -9,7 +9,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
     /// <summary>
     /// A transformation utility from WGS84 coordinates to a local tile coordinate system in pixel
     /// </summary>
-    internal struct TileGeometryTransform : ITileGeometryTransform
+    public struct TileGeometryTransform : ITileGeometryTransform
     {
         private readonly Tiles.Tile _tile;
         private readonly uint _extent;

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransformRelative.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransformRelative.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Runtime.CompilerServices;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.VectorTiles.Tiles.WebMercator;
+
+[assembly: InternalsVisibleTo("NetTopologySuite.IO.VectorTiles.Tests")]
+namespace NetTopologySuite.IO.VectorTiles.Mapbox
+{
+    /// <summary>
+    /// A transformation utility from WGS84 coordinates to a local tile coordinate system in pixel
+    /// </summary>
+    internal struct TileGeometryTransformRelative : ITileGeometryTransform
+    {
+        private readonly Tiles.Tile _tile;
+        private readonly uint _extent;
+        private readonly uint _newExtent;
+        private readonly double _factor;
+
+        /// <summary>
+        /// Initializes this transformation utility
+        /// </summary>
+        /// <param name="tile">The tile's bounds</param>
+        /// <param name="extent">The tile's extent in pixel. Tiles are always square.</param>
+        /// <param name="newExtent">The tile's new extent in pixel. Tiles are always square.</param>
+        public TileGeometryTransformRelative(Tiles.Tile tile, uint extent, uint newExtent) : this()
+        {
+            _extent = extent;
+            _newExtent = newExtent;
+            _factor = _newExtent / _extent;
+
+            // Precalculate the resolution of the tile for the specified zoom level.
+            ZoomResolution = WebMercatorHandler.Resolution(tile.Zoom, (int)extent);
+        }
+
+        /// <summary>
+        /// The zoom level pixel resolution based on the extent.
+        /// </summary>
+        public double ZoomResolution { get; }
+
+        /// <summary>
+        /// Transforms the coordinate at <paramref name="index"/> of <paramref name="sequence"/> to the tile coordinate system.
+        /// The return value is the position relative to the local point at (<paramref name="currentX"/>, <paramref name="currentY"/>).
+        /// </summary>
+        /// <param name="sequence">The input sequence</param>
+        /// <param name="index">The index of the coordinate to transform</param>
+        /// <param name="currentX">The current horizontal component of the cursor location. This value is updated.</param>
+        /// <param name="currentY">The current vertical component of the cursor location. This value is updated.</param>
+        /// <returns>The position relative to the local point at (<paramref name="currentX"/>, <paramref name="currentY"/>).</returns>
+        public (int x, int y) Transform(CoordinateSequence sequence, int index, ref int currentX, ref int currentY)
+        {
+            // This should never happen.
+            if (sequence == null)
+                throw new ArgumentNullException(nameof(sequence));
+
+            if (sequence.Count == 0)
+                throw new ArgumentException("sequence is empty.", nameof(sequence));
+
+            double originalX = sequence.GetOrdinate(index, Ordinate.X);
+            double originalY = sequence.GetOrdinate(index, Ordinate.Y);
+            
+            int localX = (int)(originalX / _factor);
+            int localY = (int)(originalY / _factor);
+            int dx = localX - currentX;
+            int dy = localY - currentY;
+            currentX = localX;
+            currentY = localY;
+
+            return (dx, dy);
+        }
+
+        /// <summary>
+        /// Transforms the point in the local tile pixel coordinates into 0..511 coordinates.
+        /// The return value is x and y of the tile pixel point (<paramref name="x"/>, <paramref name="y"/>).
+        /// </summary>
+        /// <param name="x">The horizontal component of the point in the tile coordinate system</param>
+        /// <param name="y">The vertical component of the point in the tile coordinate system</param>
+        /// <returns>0..511 coordinates of the point in tile "pixel" coordinates (<paramref name="x"/>, <paramref name="y"/>).</returns>
+        public (double longitude, double latitude) TransformInverse(int x, int y)
+        {
+            return (x * _factor, y * _factor);
+        }
+
+        /// <summary>
+        /// Check if the point with tile coordinates (<paramref name="x"/>, <paramref name="y"/> lies inside tile extent
+        /// </summary>
+        /// <param name="x">Horizontal component of the point in the tile coordinate system</param>
+        /// <param name="y">Vertical component of the point in the tile coordinate system</param>
+        /// <returns>true if point lies inside tile extent</returns>
+        public bool IsPointInExtent(int x, int y)
+        {
+            return x >= 0 && y >= 0 && x < _extent && y < _extent;
+        }
+
+        /// <summary>
+        /// Checks to see if a geometries envelope is greater than 1 square pixel in size for a specified zoom level.
+        /// </summary>
+        /// <param name="polygon">Polygon to test.</param>
+        /// <returns>true if the <paramref name="polygon"/> is greater than 1 pixel in the tile pixel coordinates</returns>
+        public bool IsGreaterThanOnePixelOfTile(Geometry geometry)
+        {
+            if (geometry.IsEmpty) return false;
+
+            var env = geometry.EnvelopeInternal;
+
+            double dx = Math.Abs(env.MaxX - env.MinX);
+            double dy = Math.Abs(env.MaxY - env.MinY);
+
+            // Both must be greater than 0, and at least one of them needs to be larger than 1. 
+            return dx > 0 && dy > 0 && (dx > 1 || dy > 1);
+        }
+
+        public (long x, long y) ExtentInPixel(Envelope env)
+        {
+            return ((long)((env.MaxX - env.MinX) / _factor), (long)((env.MaxY - env.MinY) / _factor));
+        }
+    }
+}

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransformRelative.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransformRelative.cs
@@ -9,7 +9,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
     /// <summary>
     /// A transformation utility from WGS84 coordinates to a local tile coordinate system in pixel
     /// </summary>
-    internal struct TileGeometryTransformRelative : ITileGeometryTransform
+    public struct TileGeometryTransformRelative : ITileGeometryTransform
     {
         private readonly Tiles.Tile _tile;
         private readonly uint _extent;

--- a/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransformRelative.cs
+++ b/src/NetTopologySuite.IO.VectorTiles.Mapbox/TileGeometryTransformRelative.cs
@@ -26,7 +26,7 @@ namespace NetTopologySuite.IO.VectorTiles.Mapbox
         {
             _extent = extent;
             _newExtent = newExtent;
-            _factor = _newExtent / _extent;
+            _factor = (double)_newExtent / (double)_extent;
 
             // Precalculate the resolution of the tile for the specified zoom level.
             ZoomResolution = WebMercatorHandler.Resolution(tile.Zoom, (int)extent);

--- a/test/NetTopologySuite.IO.VectorTiles.Tests/Mapbox/TileGeometryTransformRelativeTests.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Tests/Mapbox/TileGeometryTransformRelativeTests.cs
@@ -1,0 +1,64 @@
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Implementation;
+using NetTopologySuite.IO.VectorTiles.Mapbox;
+using Xunit;
+using Tile = NetTopologySuite.IO.VectorTiles.Tiles.Tile;
+
+namespace NetTopologySuite.IO.VectorTiles.Tests.Mapbox
+{
+    public class TileGeometryTransformRelativeTests
+    {
+        [Theory]
+        [InlineData(0.0, 0.0, 0, 0)]
+        [InlineData(0.0, 256.0, 0, 2048)]
+        [InlineData(100.0, 100.0, 800, 800)]
+        public void TileGeometryTransform_Transform_Regression1(double oldX, double oldY, int newX, int newY)
+        {
+            var tileGeometry = new TileGeometryTransformRelative(new Tile(0, 0, 0), 4096, 512);
+            int x = 0;
+            int y = 0;
+            tileGeometry.Transform(new CoordinateArraySequence(new Coordinate[]
+            {
+                new Coordinate(oldX, oldY),
+            }), 0, ref x, ref y);
+            
+            Assert.Equal(newX, x);
+            Assert.Equal(newY, y);
+        }
+        
+        [Fact]
+        public void TileGeometryTransform_TransformInverse_Regression2()
+        {
+            var tileGeometry = new TileGeometryTransformRelative(new Tile(0, 0, 1), 4096, 512);
+
+            (double x, double y) = tileGeometry.TransformInverse(2048, 3026);
+            
+            Assert.Equal(256.0, x);
+            Assert.Equal(378.25, y);
+        }
+
+        [Fact]
+        public void FloatingPointError()
+        {
+            const double dx = 256.125;
+            const double dy = 128.375;
+
+            var tileGeometry = new TileGeometryTransformRelative(new Tile(651, 335, 10), 4096, 512);
+            int x = 0;
+            int y = 0;
+            tileGeometry.Transform(new CoordinateArraySequence(new Coordinate[]
+            {
+                new Coordinate(dx, dy),
+            }), 0, ref x, ref y);
+                
+            Assert.Equal(2049, x);
+            Assert.Equal(1027, y);
+
+            (double actualX, double actualY) = tileGeometry.TransformInverse(x, y);
+
+            // comparing only 5 decimal places
+            Assert.Equal(dx, actualX, 5);
+            Assert.Equal(dy, actualY, 5);
+        }
+    }
+}


### PR DESCRIPTION
Hello,

I try to give back something to this wonderful project. Thank you for it.

I encountered the problem described in #27 by myself. I like to have the VectorTile in coordinates of the range 0..511 and not in WGS84. So I tried to add this functionality. With this PR it is possible to add a parameter for a function, that creates the TileGeometryTransformer when creating the reader or writer of the Mapbox tile source.