### PR TITLE
Use `BoundingBox` struct to reduce allocation

### DIFF
--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/BoundingBox.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/BoundingBox.cs
@@ -5,9 +5,9 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
     /// <summary>
     /// Represents a bounding box.
     /// </summary>
-    public struct Bounds : IEquatable<Bounds>
+    public struct BoundingBox : IEquatable<BoundingBox>
     {
-        public Bounds(double left, double bottom, double right, double top)
+        public BoundingBox(double left, double bottom, double right, double top)
         {
             Left = left;
             Bottom = bottom;
@@ -22,10 +22,10 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
 
         public readonly override bool Equals(object? obj)
         {
-            return obj is Bounds bounds && Equals(bounds);
+            return obj is BoundingBox bounds && Equals(bounds);
         }
 
-        public readonly bool Equals(Bounds other)
+        public readonly bool Equals(BoundingBox other)
         {
             return Left == other.Left &&
                    Bottom == other.Bottom &&
@@ -44,12 +44,12 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
         }
         public readonly double[] ToArray() => new double[] { Left, Bottom, Right, Top };
 
-        public static bool operator ==(Bounds left, Bounds right)
+        public static bool operator ==(BoundingBox left, BoundingBox right)
         {
             return left.Equals(right);
         }
 
-        public static bool operator !=(Bounds left, Bounds right)
+        public static bool operator !=(BoundingBox left, BoundingBox right)
         {
             return !(left == right);
         }

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/Bounds.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/Bounds.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace NetTopologySuite.IO.VectorTiles.Tiles
+{
+    /// <summary>
+    /// Represents a bounding box.
+    /// </summary>
+    public struct Bounds : IEquatable<Bounds>
+    {
+        public Bounds(double left, double bottom, double right, double top)
+        {
+            Left = left;
+            Bottom = bottom;
+            Right = right;
+            Top = top;
+        }
+
+        public double Left { readonly get; set; }
+        public double Bottom { readonly get; set; }
+        public double Right { readonly get; set; }
+        public double Top { readonly get; set; }
+
+        public readonly override bool Equals(object? obj)
+        {
+            return obj is Bounds bounds && Equals(bounds);
+        }
+
+        public readonly bool Equals(Bounds other)
+        {
+            return Left == other.Left &&
+                   Bottom == other.Bottom &&
+                   Right == other.Right &&
+                   Top == other.Top;
+        }
+
+        public readonly override int GetHashCode()
+        {
+            int hashCode = 1263652387;
+            hashCode = hashCode * -1521134295 + Left.GetHashCode();
+            hashCode = hashCode * -1521134295 + Bottom.GetHashCode();
+            hashCode = hashCode * -1521134295 + Right.GetHashCode();
+            hashCode = hashCode * -1521134295 + Top.GetHashCode();
+            return hashCode;
+        }
+        public readonly double[] ToArray() => new double[] { Left, Bottom, Right, Top };
+
+        public static bool operator ==(Bounds left, Bounds right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Bounds left, Bounds right)
+        {
+            return !(left == right);
+        }
+    }
+
+}

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/Tile.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/Tile.cs
@@ -52,7 +52,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
             //this.Right = (double)(((this.X + 1) / zoomPow * 360.0) - 180.0);
             //this.Bottom = (double)(180.0 / Math.PI * Math.Atan(Math.Sinh(n)));
 
-            var bbox = GetBBox(this.X, this.Y, this.Zoom);
+            var bbox = GetBoundingBox(this.X, this.Y, this.Zoom);
 
             this.Left = bbox.Left;
             this.Bottom = bbox.Bottom;
@@ -69,7 +69,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="zoom"></param>
-        internal static BoundingBox GetBBox(int x, int y, int zoom)
+        internal static BoundingBox GetBoundingBox(int x, int y, int zoom)
         {
             double zoomPow = (1 << zoom); // Math.Pow(2.0, this.Zoom)
             double n = Math.PI - ((2.0 * Math.PI * y) / zoomPow);

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/Tile.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/Tile.cs
@@ -69,7 +69,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="zoom"></param>
-        internal static Bounds GetBBox(int x, int y, int zoom)
+        internal static BoundingBox GetBBox(int x, int y, int zoom)
         {
             double zoomPow = (1 << zoom); // Math.Pow(2.0, this.Zoom)
             double n = Math.PI - ((2.0 * Math.PI * y) / zoomPow);
@@ -79,7 +79,7 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
             n = Math.PI - ((2.0 * Math.PI * (y + 1)) / zoomPow);
             double right = ((x + 1) / zoomPow * 360.0) - 180.0;
             double bottom = 180.0 / Math.PI * Math.Atan(Math.Sinh(n));
-            return new Bounds(left, bottom, right, top);
+            return new BoundingBox(left, bottom, right, top);
         }
         /// <summary>
         /// The X position of the tile.

--- a/src/NetTopologySuite.IO.VectorTiles/Tiles/Tile.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/Tiles/Tile.cs
@@ -52,38 +52,35 @@ namespace NetTopologySuite.IO.VectorTiles.Tiles
             //this.Right = (double)(((this.X + 1) / zoomPow * 360.0) - 180.0);
             //this.Bottom = (double)(180.0 / Math.PI * Math.Atan(Math.Sinh(n)));
 
-            double[] bbox = GetBBox(this.X, this.Y, this.Zoom);
+            var bbox = GetBBox(this.X, this.Y, this.Zoom);
 
-            this.Left = bbox[0];
-            this.Bottom = bbox[1];
-            this.Right = bbox[2];
-            this.Top = bbox[3];
+            this.Left = bbox.Left;
+            this.Bottom = bbox.Bottom;
+            this.Right = bbox.Right;
+            this.Top = bbox.Top;
 
             this.CenterLat = (double)((this.Top + this.Bottom) / 2.0);
             this.CenterLon = (double)((this.Left + this.Right) / 2.0);
         }
 
         /// <summary>
-        /// Get the bounding box for a xyz tile. In the form of a double array [minX, minY, maxX, maxY]
+        /// Get the bounding box for a xyz tile.
         /// </summary>
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="zoom"></param>
-        /// <returns></returns>
-        internal static double[] GetBBox(int x, int y, int zoom)
+        internal static Bounds GetBBox(int x, int y, int zoom)
         {
             double zoomPow = (1 << zoom); // Math.Pow(2.0, this.Zoom)
             double n = Math.PI - ((2.0 * Math.PI * y) / zoomPow);
-            double left = (double)((x / zoomPow * 360.0) - 180.0);
-            double top = (double)(180.0 / Math.PI * Math.Atan(Math.Sinh(n)));
+            double left = (x / zoomPow * 360.0) - 180.0;
+            double top = 180.0 / Math.PI * Math.Atan(Math.Sinh(n));
 
             n = Math.PI - ((2.0 * Math.PI * (y + 1)) / zoomPow);
-            double right = (double)(((x + 1) / zoomPow * 360.0) - 180.0);
-            double bottom = (double)(180.0 / Math.PI * Math.Atan(Math.Sinh(n)));
-
-            return new double[] { left, bottom, right, top };
+            double right = ((x + 1) / zoomPow * 360.0) - 180.0;
+            double bottom = 180.0 / Math.PI * Math.Atan(Math.Sinh(n));
+            return new Bounds(left, bottom, right, top);
         }
-
         /// <summary>
         /// The X position of the tile.
         /// </summary>

--- a/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
@@ -58,7 +58,7 @@ namespace NetTopologySuite.IO.VectorTiles
         [Obsolete("Use overload with Tiles.Bounds instead.", false)]
         public void GetExtents(out double[] bounds, out int minZoom, out int maxZoom)
         {
-            GetExtents(out Tiles.Bounds bbox, out minZoom, out maxZoom);
+            GetExtents(out Tiles.BoundingBox bbox, out minZoom, out maxZoom);
             bounds = new double[] { bbox.Left, bbox.Bottom, bbox.Right, bbox.Top };
         }
         /// <summary>
@@ -68,7 +68,7 @@ namespace NetTopologySuite.IO.VectorTiles
         /// <param name="minZoom">The min zoom level.</param>
         /// /// <param name="maxZoom">The max zoom level.</param>
         /// <returns></returns>
-        public void GetExtents(out Tiles.Bounds bounds, out int minZoom, out int maxZoom)
+        public void GetExtents(out Tiles.BoundingBox bounds, out int minZoom, out int maxZoom)
         {
             var ids = GetTileIds();
 

--- a/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 
 namespace NetTopologySuite.IO.VectorTiles
 {
@@ -55,7 +56,20 @@ namespace NetTopologySuite.IO.VectorTiles
         /// <param name="minZoom">The min zoom level.</param>
         /// /// <param name="maxZoom">The max zoom level.</param>
         /// <returns></returns>
+        [Obsolete("Use overload with Tiles.Bounds instead.", false)]
         public void GetExtents(out double[] bounds, out int minZoom, out int maxZoom)
+        {
+            GetExtents(out Tiles.Bounds bbox, out minZoom, out maxZoom);
+            bounds = new double[] { bbox.Left, bbox.Bottom, bbox.Right, bbox.Top };
+        }
+        /// <summary>
+        /// Gets the bounding box and min/max zoom level of the tile tree.
+        /// </summary>
+        /// <param name="bounds">Bounding box.</param>
+        /// <param name="minZoom">The min zoom level.</param>
+        /// /// <param name="maxZoom">The max zoom level.</param>
+        /// <returns></returns>
+        public void GetExtents(out Tiles.Bounds bounds, out int minZoom, out int maxZoom)
         {
             var ids = GetTileIds();
 
@@ -72,8 +86,6 @@ namespace NetTopologySuite.IO.VectorTiles
 
             bounds = Tiles.Tile.GetBBox(x, y, z);
 
-            double[] bbox;
-
             foreach (ulong id in ids)
             {
                 (x, y, z) = Tiles.Tile.CalculateTile(id);
@@ -84,12 +96,12 @@ namespace NetTopologySuite.IO.VectorTiles
                 //Only need to calculate the bbox for the min zoom level. 
                 if (z == minZoom)
                 {
-                    bbox = Tiles.Tile.GetBBox(x, y, z);
+                    var bbox = Tiles.Tile.GetBBox(x, y, z);
 
-                    bounds[0] = Math.Min(bbox[0], bounds[0]);
-                    bounds[1] = Math.Min(bbox[1], bounds[1]);
-                    bounds[2] = Math.Max(bbox[2], bounds[2]);
-                    bounds[2] = Math.Max(bbox[2], bounds[2]);
+                    bounds.Left = Math.Min(bbox.Left, bounds.Left);
+                    bounds.Bottom = Math.Min(bbox.Bottom, bounds.Bottom);
+                    bounds.Right = Math.Max(bbox.Right, bounds.Right);
+                    bounds.Top = Math.Max(bbox.Top, bounds.Top);
                 }
             }
         }

--- a/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
@@ -55,10 +55,10 @@ namespace NetTopologySuite.IO.VectorTiles
         /// <param name="minZoom">The min zoom level.</param>
         /// /// <param name="maxZoom">The max zoom level.</param>
         /// <returns></returns>
-        [Obsolete("Use overload with Tiles.Bounds instead.", false)]
+        [Obsolete("Use GetBoundingBox instead.", false)]
         public void GetExtents(out double[] bounds, out int minZoom, out int maxZoom)
         {
-            GetExtents(out Tiles.BoundingBox bbox, out minZoom, out maxZoom);
+            GetBoundingBox(out var bbox, out minZoom, out maxZoom);
             bounds = new double[] { bbox.Left, bbox.Bottom, bbox.Right, bbox.Top };
         }
         /// <summary>
@@ -68,7 +68,7 @@ namespace NetTopologySuite.IO.VectorTiles
         /// <param name="minZoom">The min zoom level.</param>
         /// /// <param name="maxZoom">The max zoom level.</param>
         /// <returns></returns>
-        public void GetExtents(out Tiles.BoundingBox bounds, out int minZoom, out int maxZoom)
+        public void GetBoundingBox(out Tiles.BoundingBox bounds, out int minZoom, out int maxZoom)
         {
             var ids = GetTileIds();
 
@@ -83,7 +83,7 @@ namespace NetTopologySuite.IO.VectorTiles
             minZoom = z;
             maxZoom = z;
 
-            bounds = Tiles.Tile.GetBBox(x, y, z);
+            bounds = Tiles.Tile.GetBoundingBox(x, y, z);
 
             foreach (ulong id in ids)
             {
@@ -95,7 +95,7 @@ namespace NetTopologySuite.IO.VectorTiles
                 //Only need to calculate the bbox for the min zoom level. 
                 if (z == minZoom)
                 {
-                    var bbox = Tiles.Tile.GetBBox(x, y, z);
+                    var bbox = Tiles.Tile.GetBoundingBox(x, y, z);
 
                     bounds.Left = Math.Min(bbox.Left, bounds.Left);
                     bounds.Bottom = Math.Min(bbox.Bottom, bounds.Bottom);

--- a/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
+++ b/src/NetTopologySuite.IO.VectorTiles/VectorTileTree.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 
 namespace NetTopologySuite.IO.VectorTiles
 {

--- a/test/NetTopologySuite.IO.VectorTiles.Samples/Pages/Index.cshtml
+++ b/test/NetTopologySuite.IO.VectorTiles.Samples/Pages/Index.cshtml
@@ -22,7 +22,7 @@
 <script>
     const minZoom = @Model.MinZoom;
     const maxZoom = @Model.MaxZoom;
-    const bounds = @Html.Raw(Json.Serialize(Model.BBox));
+    const bounds = @Html.Raw(Json.Serialize(Model.BBox.ToArray()));
 
     const map = new maplibregl.Map({
         container: 'map',

--- a/test/NetTopologySuite.IO.VectorTiles.Samples/Pages/Index.cshtml.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Samples/Pages/Index.cshtml.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
+using NetTopologySuite.IO.VectorTiles.Tiles;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,13 +22,13 @@ namespace NetTopologySuite.IO.VectorTiles.Samples.Pages
         {
 
         }
-        public double[] BBox { get { return IndexModel._BBox; } }
+        public Bounds BBox { get { return IndexModel._BBox; } }
 
         public int MinZoom { get { return IndexModel._MinZoom; } }
 
         public int MaxZoom { get { return IndexModel._MaxZoom; } }
 
-        internal static double[] _BBox;
+        internal static Bounds _BBox;
         internal static int _MinZoom;
         internal static int _MaxZoom;
     }

--- a/test/NetTopologySuite.IO.VectorTiles.Samples/Pages/Index.cshtml.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Samples/Pages/Index.cshtml.cs
@@ -22,13 +22,13 @@ namespace NetTopologySuite.IO.VectorTiles.Samples.Pages
         {
 
         }
-        public Bounds BBox { get { return IndexModel._BBox; } }
+        public BoundingBox BBox { get { return IndexModel._BBox; } }
 
         public int MinZoom { get { return IndexModel._MinZoom; } }
 
         public int MaxZoom { get { return IndexModel._MaxZoom; } }
 
-        internal static Bounds _BBox;
+        internal static BoundingBox _BBox;
         internal static int _MinZoom;
         internal static int _MaxZoom;
     }

--- a/test/NetTopologySuite.IO.VectorTiles.Samples/Startup.cs
+++ b/test/NetTopologySuite.IO.VectorTiles.Samples/Startup.cs
@@ -111,7 +111,7 @@ namespace NetTopologySuite.IO.VectorTiles.Samples
 
             var tree = new VectorTileTree { { features, ConfigureFeature } };
 
-            tree.GetExtents(out Pages.IndexModel._BBox, out Pages.IndexModel._MinZoom, out Pages.IndexModel._MaxZoom);
+            tree.GetBoundingBox(out Pages.IndexModel._BBox, out Pages.IndexModel._MinZoom, out Pages.IndexModel._MaxZoom);
 
             tree.Write("wwwroot/tiles", MapboxTileWriter.DefaultMinLinealExtent, MapboxTileWriter.DefaultMinPolygonalExtent);
         }


### PR DESCRIPTION
Representing bounds as array makes unnecessary allocations.
Use `Bounds` struct to reduce allocations.